### PR TITLE
Adds `pattern` option to filter backup filenames.

### DIFF
--- a/lib/trashman/cli.rb
+++ b/lib/trashman/cli.rb
@@ -19,6 +19,8 @@ module TrashMan
       desc: "Credentials for your fog provider (depends on fog provider)."
     method_option :dry_run, type: :boolean, default: false,
       desc: "As normal, but it does not destroy old backups."
+    method_option :pattern, type: :string,
+      desc: "A regular expression to only consider matching filenames for pruning."
     def prune
       if options.dry_run
         say "This is a dry-run. No files will be deleted."

--- a/lib/trashman/manager.rb
+++ b/lib/trashman/manager.rb
@@ -38,7 +38,13 @@ module TrashMan
     end
 
     def files
-      @files ||= container.files.sort_by { |file| file.key }
+      @files ||= begin
+        if options[:pattern]
+          container.files.select { |file| file.key =~ Regexp.new(options[:pattern]) }
+        else
+          container.files
+        end.sort_by { |file| file.key }
+      end
     end
 
     def queued_files

--- a/spec/trashman/manager_spec.rb
+++ b/spec/trashman/manager_spec.rb
@@ -59,5 +59,14 @@ describe TrashMan::Manager do
 
       TrashMan::Manager.new("rackspace", { credentials: {}, keep: 3, dry_run: true }).cleanup!
     end
+
+    it "ignores files which don't match the pattern" do
+      backup = MockFogFile.new("anotherbackup.2014-12-31T10-00-01.tar.gz")
+      MockFogContainer.instance.files.unshift(backup)
+      expect(backup).to_not receive(:destroy)
+
+      TrashMan::Manager.new("rackspace", { credentials: {}, keep: 3, pattern: "\Abackup.*tgz\z" }).cleanup!
+      MockFogContainer.instance.files.shift
+    end
   end
 end


### PR DESCRIPTION
This is useful in a few ways:
- When uploading large files to Rackspace, you need to do a chunked
upload. This results in multiple files generated per backup. Those
chunked files should not be eligible for deletion.
- If you store different types of backup in the same directory.